### PR TITLE
fix: add py.typed marker and fix mypy --strict errors

### DIFF
--- a/src/agent_memory_guard/integrations/langchain.py
+++ b/src/agent_memory_guard/integrations/langchain.py
@@ -21,18 +21,18 @@ try:  # pragma: no cover - optional dependency
 
     _HAS_LANGCHAIN = True
 except Exception:  # pragma: no cover - optional dependency
-    BaseChatMessageHistory = object  # type: ignore[assignment, misc]
-    BaseMessage = Any  # type: ignore[assignment, misc]
+    BaseChatMessageHistory = object  # type: ignore[assignment, misc, unused-ignore]
+    BaseMessage = Any  # type: ignore[assignment, misc, unused-ignore]
     _HAS_LANGCHAIN = False
 
-    def messages_from_dict(d):  # type: ignore[no-redef]
+    def messages_from_dict(d: list[dict[str, Any]]) -> list[Any]:  # type: ignore[no-redef, unused-ignore]
         return list(d)
 
-    def messages_to_dict(m):  # type: ignore[no-redef]
+    def messages_to_dict(m: list[Any]) -> list[dict[str, Any]]:  # type: ignore[no-redef, unused-ignore]
         return list(m)
 
 
-class GuardedChatMessageHistory(BaseChatMessageHistory):  # type: ignore[misc, valid-type]
+class GuardedChatMessageHistory(BaseChatMessageHistory):  # type: ignore[misc, valid-type, unused-ignore]
     """Chat history whose messages are screened by a MemoryGuard before storage.
 
     Each message is written under the key ``messages.<session_id>.<index>``,
@@ -91,6 +91,6 @@ class GuardedChatMessageHistory(BaseChatMessageHistory):  # type: ignore[misc, v
                 pass
         self.guard.write(self._index_key, 0, source="langchain")
 
-    def _iter_store(self):
+    def _iter_store(self) -> list[tuple[str, Any]]:
         store = self.guard._store  # noqa: SLF001 - intentional internal access
         return list(store.items())

--- a/src/agent_memory_guard/policies/policy.py
+++ b/src/agent_memory_guard/policies/policy.py
@@ -106,11 +106,12 @@ def _parse_action(value: Any) -> Action:
     return Action(text)
 
 
-def _parse_rule(raw: dict[str, Any]) -> PolicyRule:
+def _parse_rule(raw: dict[str | bool, Any]) -> PolicyRule:
     # YAML 1.1 parses unquoted `on` as the boolean True; remap it to the
     # intended string key so users can write natural policy files.
     if True in raw and "on" not in raw:
-        raw = {**raw, "on": raw[True]}
+        raw_str: dict[str | bool, Any] = {**raw, "on": raw[True]}
+        raw = raw_str
     if "name" not in raw or "action" not in raw:
         raise ValueError(f"Policy rule missing required fields: {raw!r}")
     keys = raw.get("keys") or ()


### PR DESCRIPTION
Closes #1

## What
Adds the `py.typed` marker and fixes all `mypy --strict` errors across the package.

## Changes
- **`src/agent_memory_guard/py.typed`** — new PEP 561 marker file
- **`policies/policy.py`** — widen `_parse_rule()` signature to `dict[str | bool, Any]` to handle YAML 1.1's boolean key quirk (`on:` → `True`)
- **`integrations/langchain.py`** — add return type to `_iter_store()`, add full type annotations to fallback stubs, consolidate `type: ignore` comments

## Verification
```
mypy src/agent_memory_guard --strict  # Success: 0 errors in 18 files
pytest                                 # 29 passed in 0.11s
```