### PR TITLE
feat: add GitHub Action for scanning agent memory vulnerabilities

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,40 @@
+name: 'Agent Memory Guard Scanner'
+description: 'Scan AI agent projects for memory poisoning vulnerabilities'
+author: 'OWASP Agent Memory Guard'
+
+branding:
+  icon: 'shield'
+  color: 'red'
+
+inputs:
+  policy:
+    description: 'Policy level (strict, moderate, basic)'
+    required: false
+    default: 'moderate'
+  fail-on:
+    description: 'Fail threshold (high, medium, low)'
+    required: false
+    default: 'high'
+  path:
+    description: 'Path to scan'
+    required: false
+    default: '.'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Run Agent Memory Guard Scanner
+      shell: bash
+      run: |
+        pip install -q pyyaml
+        python ${{ github.action_path }}/scanner/scan.py \
+          --path "${{ inputs.path }}" \
+          --policy "${{ inputs.policy }}" \
+          --fail-on "${{ inputs.fail-on }}" \
+          --output sarif \
+          --output-file results.sarif
+
+    - name: Upload SARIF results
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: results.sarif

--- a/scanner/__init__.py
+++ b/scanner/__init__.py
@@ -1,0 +1,1 @@
+"""Agent Memory Guard Scanner - GitHub Action scanning module."""

--- a/scanner/rules.py
+++ b/scanner/rules.py
@@ -1,0 +1,64 @@
+"""Scan rules for Agent Memory Guard."""
+
+import re
+
+
+def _unprotected_memory_write(content: str, filepath) -> list[dict]:
+    """Detect unprotected memory writes."""
+    results = []
+    pattern = re.compile(r'(memory|state)\[["\']?\w+["\']?\]\s*=\s*', re.IGNORECASE)
+    guard_pattern = re.compile(r'guard\.(wrap|check|protect)', re.IGNORECASE)
+    
+    for i, line in enumerate(content.split("\n"), 1):
+        if pattern.search(line) and not guard_pattern.search(line):
+            results.append({"line": i, "column": 0})
+    return results
+
+
+def _hardcoded_secrets(content: str, filepath) -> list[dict]:
+    """Detect hardcoded secrets."""
+    results = []
+    secret_patterns = [
+        r'(?i)(api_key|secret|password|token)\s*=\s*["\'][^"\']+["\']',
+        r'(?i)(sk-[a-zA-Z0-9]{20,})',
+        r'(?i)(ghp_[a-zA-Z0-9]{36})',
+    ]
+    for pat in secret_patterns:
+        for i, line in enumerate(content.split("\n"), 1):
+            if re.search(pat, line):
+                results.append({"line": i, "column": 0})
+    return results
+
+
+def _missing_policy_file(content: str, filepath) -> list[dict]:
+    """Check if policy file is referenced but missing."""
+    results = []
+    policy_dir = filepath.parent / "policies"
+    if "policy" in content.lower() and not policy_dir.exists():
+        results.append({"line": 1, "column": 0})
+    return results
+
+
+SCAN_RULES = [
+    {
+        "id": "AMG-001",
+        "pattern": _unprotected_memory_write,
+        "message": "Unprotected memory write detected — wrap with guard protection",
+        "severity": "high",
+        "min_policy": 1,
+    },
+    {
+        "id": "AMG-002",
+        "pattern": _hardcoded_secrets,
+        "message": "Hardcoded secret or credential found in source code",
+        "severity": "high",
+        "min_policy": 0,
+    },
+    {
+        "id": "AMG-003",
+        "pattern": _missing_policy_file,
+        "message": "Policy file referenced but policies/ directory not found",
+        "severity": "medium",
+        "min_policy": 2,
+    },
+]

--- a/scanner/sarif_output.py
+++ b/scanner/sarif_output.py
@@ -1,0 +1,49 @@
+"""SARIF output formatter for Agent Memory Guard."""
+
+import json
+
+
+def write_sarif(results: list[dict], output_file: str):
+    """Write scan results in SARIF 2.1.0 format."""
+    sarif = {
+        "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "Agent Memory Guard",
+                        "organization": "OWASP",
+                        "semanticVersion": "1.0.0",
+                        "rules": list({
+                            "id": r["rule_id"],
+                            "shortDescription": {"text": r["message"]},
+                            "defaultConfiguration": {"level": r["severity"]},
+                        } for r in results),
+                    }
+                },
+                "results": [
+                    {
+                        "ruleId": r["rule_id"],
+                        "message": {"text": r["message"]},
+                        "level": r["severity"],
+                        "locations": [
+                            {
+                                "physicalLocation": {
+                                    "artifactLocation": {"uri": r["file"]},
+                                    "region": {
+                                        "startLine": r["line"],
+                                        "startColumn": r["column"],
+                                    },
+                                }
+                            }
+                        ],
+                    }
+                    for r in results
+                ],
+            }
+        ],
+    }
+
+    with open(output_file, "w") as f:
+        json.dump(sarif, f, indent=2)

--- a/scanner/scan.py
+++ b/scanner/scan.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Main scanner script for Agent Memory Guard GitHub Action."""
+
+import argparse
+import sys
+from pathlib import Path
+
+from scanner.rules import SCAN_RULES
+from scanner.sarif_output import write_sarif
+
+
+def scan_file(filepath: Path, policy: str) -> list[dict]:
+    """Scan a single file for memory vulnerabilities."""
+    results = []
+    try:
+        content = filepath.read_text(encoding="utf-8")
+    except Exception:
+        return results
+
+    for rule in SCAN_RULES:
+        if rule["min_policy"] > {"basic": 0, "moderate": 1, "strict": 2}[policy]:
+            continue
+        for match in rule["pattern"](content, filepath):
+            results.append({
+                "rule_id": rule["id"],
+                "message": rule["message"],
+                "severity": rule["severity"],
+                "file": str(filepath),
+                "line": match.get("line", 1),
+                "column": match.get("column", 1),
+            })
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Agent Memory Guard Scanner")
+    parser.add_argument("--path", default=".", help="Path to scan")
+    parser.add_argument("--policy", default="moderate", choices=["basic", "moderate", "strict"])
+    parser.add_argument("--fail-on", default="high", choices=["low", "medium", "high"])
+    parser.add_argument("--output", default="sarif")
+    parser.add_argument("--output-file", default="results.sarif")
+    args = parser.parse_args()
+
+    scan_root = Path(args.path)
+    all_results = []
+
+    for py_file in scan_root.rglob("*.py"):
+        all_results.extend(scan_file(py_file, args.policy))
+
+    if args.output == "sarif":
+        write_sarif(all_results, args.output_file)
+
+    severity_levels = {"low": 0, "medium": 1, "high": 2}
+    max_severity = max(
+        (severity_levels.get(r["severity"].lower(), 0) for r in all_results),
+        default=0,
+    )
+
+    print(f"Scanned: {len(all_results)} issue(s) found.")
+    if max_severity >= severity_levels[args.fail_on]:
+        print(f"Failing due to {args.fail_on} severity or higher.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Created a reusable GitHub Action that scans AI agent projects for 
memory poisoning vulnerabilities.

## Changes
- **action.yml** — GitHub Action definition with configurable inputs
- **scanner/scan.py** — Main scanning script
- **scanner/rules.py** — Detection rules (AMG-001, AMG-002, AMG-003)
- **scanner/sarif_output.py** — SARIF 2.1.0 output formatter

## Features
- 🔍 Detects unprotected memory writes
- 🔑 Finds hardcoded secrets and API keys
- 📋 Checks for missing policy files
- 📊 SARIF output for GitHub Security tab
- ⚙️ Configurable severity threshold

## Usage
```yaml
- uses: OWASP/www-project-agent-memory-guard@v1
  with:
    policy: strict
    fail-on: high