### PR TITLE
ci: fix ruff I001 import-sort failures

### DIFF
--- a/src/agent_memory_guard/detectors/cross_task.py
+++ b/src/agent_memory_guard/detectors/cross_task.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 from typing import Any
 
 from agent_memory_guard.classification import (
-    ClassificationRegistry,
     DURABLE_CLASSES,
+    ClassificationRegistry,
     MemoryClass,
 )
 from agent_memory_guard.detectors.base import DetectionResult

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -11,9 +11,9 @@ microsoft/autogen#7673 (discussioncomment-16895746):
 import pytest
 
 from agent_memory_guard import (
+    ClassificationError,
     MemoryClass,
     MemoryGuard,
-    ClassificationError,
 )
 
 


### PR DESCRIPTION
Sort imports in cross_task.py and test_classification.py so `ruff check` passes on Python 3.9-3.12. Tests still pass locally (41/41).