### PR TITLE
chore: ignore coverage artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ __pycache__/
 .venv/
 build/
 dist/
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/


### PR DESCRIPTION
`coverage` drops `.coverage` / `coverage.xml` / `htmlcov/` next to the repo root whenever it's run locally; these are build artifacts and should not show up in `git status` as untracked.

CI uploads `coverage.xml` via `actions/upload-artifact`, so ignoring it locally has no effect there — the workflow generates and uploads it fresh each run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xgcr8Ha9QeRSjGnPFheP8K)_