### PR TITLE
docs: add Google-style docstrings to all public classes and methods

### DIFF
--- a/src/agent_memory_guard/detectors/anomaly.py
+++ b/src/agent_memory_guard/detectors/anomaly.py
@@ -10,7 +10,14 @@ from agent_memory_guard.events import Severity
 
 
 class SizeAnomalyDetector:
-    """Flags memory writes that are unusually large or grow unusually fast."""
+    """Flags memory writes that are unusually large or grow unusually fast.
+
+    This detector mitigates buffer overflow or massive data poisoning attempts
+    by enforcing maximum size limits and detecting abrupt spikes in size.
+
+    Attributes:
+        name: The unique identifier for this detector.
+    """
 
     name = "size_anomaly"
 
@@ -26,6 +33,16 @@ class SizeAnomalyDetector:
         self._severity = severity
 
     def inspect(self, key: str, value: Any, *, operation: str) -> DetectionResult:
+        """Inspect the size of a memory value.
+
+        Args:
+            key: The memory key being modified.
+            value: The string or raw value to inspect.
+            operation: The memory operation being performed.
+
+        Returns:
+            DetectionResult: The match outcome, including size details if a violation occurs.
+        """
         size = len(_stringify(value).encode("utf-8"))
         previous = self._last_size.get(key)
         self._last_size[key] = size
@@ -52,7 +69,14 @@ class SizeAnomalyDetector:
 
 
 class RapidChangeDetector:
-    """Flags suspiciously high write frequency on a single key (churn attack)."""
+    """Flags suspiciously high write frequency on a single key (churn attack).
+
+    This detector identifies automated loop or denial-of-service attempts
+    affecting key persistence.
+
+    Attributes:
+        name: The unique identifier for this detector.
+    """
 
     name = "rapid_change"
 
@@ -68,6 +92,16 @@ class RapidChangeDetector:
         self._severity = severity
 
     def inspect(self, key: str, value: Any, *, operation: str) -> DetectionResult:
+        """Inspect write frequency for a memory key.
+
+        Args:
+            key: The memory key being updated.
+            value: The value being written.
+            operation: The operation name. Only checks 'write' operations.
+
+        Returns:
+            DetectionResult: The check result including write frequency details.
+        """
         if operation != "write":
             return DetectionResult(self.name, matched=False)
 

--- a/src/agent_memory_guard/detectors/base.py
+++ b/src/agent_memory_guard/detectors/base.py
@@ -18,6 +18,27 @@ class DetectionResult:
 
 
 class Detector(Protocol):
+    """Protocol defining the interface for memory guard detectors.
+
+    Detectors inspect memory read and write operations to identify security events,
+    anomalies, or injections.
+
+    Attributes:
+        name: The unique string identifier of the detector.
+    """
+
     name: str
 
-    def inspect(self, key: str, value: Any, *, operation: str) -> DetectionResult: ...
+    def inspect(self, key: str, value: Any, *, operation: str) -> DetectionResult:
+        """Inspect a memory operation for security findings.
+
+        Args:
+            key: The memory key being accessed or written.
+            value: The value being read or written.
+            operation: The memory operation (e.g. 'read', 'write').
+
+        Returns:
+            DetectionResult: The verdict containing match status, severity,
+                and details.
+        """
+        ...

--- a/src/agent_memory_guard/detectors/cross_task.py
+++ b/src/agent_memory_guard/detectors/cross_task.py
@@ -19,7 +19,14 @@ from agent_memory_guard.events import Severity
 
 
 class CrossTaskContaminationDetector:
-    """Match on read: durable memory accessed outside its origin task."""
+    """Flags reads of durable memory from a different task than the one that produced it.
+
+    This detector prevents cross-task context contamination (e.g., tool results
+    from Task A leaking into Task B's agent reasoning).
+
+    Attributes:
+        name: The unique identifier for this detector.
+    """
 
     name = "cross_task_contamination"
 
@@ -37,9 +44,24 @@ class CrossTaskContaminationDetector:
         self._severity = severity
 
     def set_current_task(self, task_id: str | None) -> None:
+        """Switch the current active task identifier.
+
+        Args:
+            task_id: The ID of the task context to switch to.
+        """
         self._current_task = task_id
 
     def inspect(self, key: str, value: Any, *, operation: str) -> DetectionResult:
+        """Inspect read operations for cross-task contamination.
+
+        Args:
+            key: The memory key being accessed.
+            value: The stored value being read.
+            operation: The memory operation being performed. Only screens 'read' operations.
+
+        Returns:
+            DetectionResult: The check outcome, matched=True if cross-task leakage is detected.
+        """
         if operation != "read":
             return DetectionResult(self.name, matched=False)
         mclass = self._registry.get(key)

--- a/src/agent_memory_guard/detectors/injection.py
+++ b/src/agent_memory_guard/detectors/injection.py
@@ -22,7 +22,14 @@ DEFAULT_INJECTION_PATTERNS: tuple[str, ...] = (
 
 
 class PromptInjectionDetector:
-    """Regex-based screen for indirect prompt-injection markers in memory values."""
+    """Regex-based screen for indirect prompt-injection markers in memory values.
+
+    This detector monitors memory inputs for common injection keywords, instructions
+    overrides, jailbreak phrases, and system prompt leakage attempts.
+
+    Attributes:
+        name: The unique identifier for this detector.
+    """
 
     name = "prompt_injection"
 
@@ -35,6 +42,16 @@ class PromptInjectionDetector:
         self._severity = severity
 
     def inspect(self, key: str, value: Any, *, operation: str) -> DetectionResult:
+        """Inspect a memory value for potential prompt injection patterns.
+
+        Args:
+            key: The memory key being targeted.
+            value: The data value to inspect.
+            operation: The memory operation being performed.
+
+        Returns:
+            DetectionResult: The check result including list of pattern matches if any.
+        """
         text = _stringify(value)
         if not text:
             return DetectionResult(self.name, matched=False)

--- a/src/agent_memory_guard/detectors/leakage.py
+++ b/src/agent_memory_guard/detectors/leakage.py
@@ -26,7 +26,14 @@ DEFAULT_LEAKAGE_PATTERNS: dict[str, str] = {
 
 
 class SensitiveDataDetector:
-    """Flags secrets/PII present in memory values prior to write or after read."""
+    """Flags secrets/PII present in memory values prior to write or after read.
+
+    This detector checks inputs for API keys, tokens, SSH keys, emails, credit card details,
+    and US Social Security Numbers.
+
+    Attributes:
+        name: The unique identifier for this detector.
+    """
 
     name = "sensitive_data"
 
@@ -43,6 +50,16 @@ class SensitiveDataDetector:
         self._severity = severity
 
     def inspect(self, key: str, value: Any, *, operation: str) -> DetectionResult:
+        """Inspect a memory value for sensitive data/leakage markers.
+
+        Args:
+            key: The memory key being targeted.
+            value: The data value to inspect.
+            operation: The memory operation being performed.
+
+        Returns:
+            DetectionResult: The check result including list of matching categories.
+        """
         text = _stringify(value)
         if not text:
             return DetectionResult(self.name, matched=False)
@@ -64,6 +81,16 @@ class SensitiveDataDetector:
         )
 
     def redact(self, value: Any) -> Any:
+        """Redact sensitive data patterns from a memory value.
+
+        Replaces matching occurrences with a redaction placeholder.
+
+        Args:
+            value: The memory value containing sensitive data.
+
+        Returns:
+            Any: The redacted text value.
+        """
         text = _stringify(value)
         for label, pattern in self._patterns.items():
             text = pattern.sub(f"[REDACTED:{label}]", text)

--- a/src/agent_memory_guard/detectors/protected_keys.py
+++ b/src/agent_memory_guard/detectors/protected_keys.py
@@ -9,7 +9,11 @@ from agent_memory_guard.events import Severity
 
 
 class ProtectedKeyDetector:
-    """Flags writes targeting keys declared immutable by policy."""
+    """Flags writes targeting keys declared protected or immutable by policy.
+
+    Attributes:
+        name: The unique identifier for this detector.
+    """
 
     name = "protected_key"
 
@@ -22,15 +26,38 @@ class ProtectedKeyDetector:
         self._severity = severity
 
     def add(self, pattern: str) -> None:
+        """Add a key pattern to the collection of protected keys.
+
+        Args:
+            pattern: The glob pattern matching protected keys.
+        """
         self._patterns.append(pattern)
 
     def matches(self, key: str) -> str | None:
+        """Check if a memory key matches any protected patterns.
+
+        Args:
+            key: The memory key to check.
+
+        Returns:
+            str | None: The matching glob pattern, or None if no match is found.
+        """
         for pattern in self._patterns:
             if fnmatch.fnmatchcase(key, pattern):
                 return pattern
         return None
 
     def inspect(self, key: str, value: Any, *, operation: str) -> DetectionResult:
+        """Inspect write operations to prevent modification of protected keys.
+
+        Args:
+            key: The target memory key.
+            value: The value being written.
+            operation: The memory operation being performed. Only checks 'write' operations.
+
+        Returns:
+            DetectionResult: The check outcome, matched=True if targeting a protected key.
+        """
         if operation != "write":
             return DetectionResult(self.name, matched=False)
         match = self.matches(key)

--- a/src/agent_memory_guard/detectors/self_reinforcement.py
+++ b/src/agent_memory_guard/detectors/self_reinforcement.py
@@ -40,9 +40,12 @@ class _SelfWriteHistory:
 class SelfReinforcementDetector:
     """Flags rapid, self-similar agent_authored writes to the same key.
 
-    Only fires on writes whose `source_class == AGENT_AUTHORED`. Writes
-    from other source classes (`EXTERNAL_TOOL`, `USER_INPUT`, `SYSTEM`)
-    are treated as independent evidence and reset the cool-down counter.
+    Only fires on writes whose source_class is AGENT_AUTHORED. Writes from other
+    source classes (EXTERNAL_TOOL, USER_INPUT, SYSTEM) are treated as independent
+    evidence and reset the cool-down counter.
+
+    Attributes:
+        name: The unique identifier for this detector.
     """
 
     name = "self_reinforcement"
@@ -68,21 +71,42 @@ class SelfReinforcementDetector:
         self._by_key: dict[str, _SelfWriteHistory] = {}
 
     def reset(self, key: str | None = None) -> None:
+        """Reset the write history cache for a specific key or all keys.
+
+        Args:
+            key: The memory key to clear history for. If None, clears history
+                for all keys. Defaults to None.
+        """
         if key is None:
             self._by_key.clear()
         else:
             self._by_key.pop(key, None)
 
     def note_independent_write(self, key: str) -> None:
-        """Called by `MemoryGuard` when a non-agent_authored write lands;
-        clears the cool-down counter so the next agent write isn't penalised
-        for self-reinforcement when independent evidence has just arrived."""
+        """Record an independent (non-agent-authored) write on a key.
+
+        This clears the self-reinforcement cool-down history for that key,
+        preventing subsequent writes from being flagged as self-reinforcement.
+
+        Args:
+            key: The memory key written to.
+        """
         history = self._by_key.get(key)
         if history is not None:
             history.writes.clear()
             history.last_independent_write_at = time.monotonic()
 
     def inspect(self, key: str, value: Any, *, operation: str) -> DetectionResult:
+        """Inspect write operations to detect self-reinforcement loops.
+
+        Args:
+            key: The memory key being targeted.
+            value: The data value being written.
+            operation: The memory operation. Only checks 'write' operations.
+
+        Returns:
+            DetectionResult: The check outcome, matched=True if a loop is detected.
+        """
         # source_class is carried on the inspect call via a contextvar-style
         # convention: the guard sets it on the detector before each write.
         # We default to UNKNOWN if no class was set.

--- a/src/agent_memory_guard/events.py
+++ b/src/agent_memory_guard/events.py
@@ -42,7 +42,22 @@ class SourceClass(str, Enum):
 
 @dataclass
 class SecurityEvent:
-    """Structured record of a guard decision, suitable for SIEM forwarding."""
+    """Structured record of a guard decision, suitable for SIEM forwarding.
+
+    Attributes:
+        detector: The name of the detector that triggered this event.
+        severity: The severity level of the detected event.
+        action: The mitigation action taken by the policy engine.
+        key: The memory key being accessed.
+        message: Descriptive log message outlining the finding.
+        operation: The database/memory operation name. Defaults to "write".
+        source_class: Provenance of the write operation. Defaults to SourceClass.UNKNOWN.
+        receipt_uri: Optional URI pointing to an external cryptographically signed audit receipt.
+            Defaults to None.
+        metadata: Arbitrary additional event metadata. Defaults to an empty dict.
+        timestamp: Epoch timestamp when the event was recorded. Defaults to current time.
+        event_id: Unique string identifier for this event. Defaults to a random UUID.
+    """
 
     detector: str
     severity: Severity

--- a/src/agent_memory_guard/guard.py
+++ b/src/agent_memory_guard/guard.py
@@ -37,12 +37,27 @@ EventHandler = Callable[[SecurityEvent], None]
 
 
 class MemoryGuard:
-    """Wraps a memory store and screens every read/write through detectors+policy.
+    """Wraps a memory store and screens every read/write through detectors and policies.
 
-    The guard is intentionally permissive by default: instantiating with no
-    arguments yields a working `MemoryGuard()` that detects threats and emits
-    events but does not block writes. Pass `policy=Policy.strict()` (or load
-    from YAML) to enable enforcement actions.
+    The guard acts as an intermediary runtime defense layer. It is intentionally permissive
+    by default: instantiating with no arguments yields a guard that detects threats and
+    emits events but does not block writes. Pass `policy=Policy.strict()` (or load from YAML)
+    to enable active enforcement.
+
+    Args:
+        store: The backing MemoryStore instance. If None, InMemoryStore is used.
+        policy: The active security Policy to enforce. If None, Policy.permissive() is used.
+        detectors: Optional collection of Detector instances. If None, a default suite is initialized.
+        snapshots: Store to manage memory state snapshots. If None, SnapshotStore is initialized.
+        event_handlers: Callbacks triggered whenever security events are emitted.
+        snapshot_on_block: If True, captures a snapshot when a write is blocked. Defaults to True.
+        promotion_rules: Rules dictating valid class transitions. Defaults to PromotionRules().
+        current_task: Optional initial task ID for cross-task contamination checks.
+
+    Example:
+        >>> from agent_memory_guard import MemoryGuard, Policy
+        >>> guard = MemoryGuard(policy=Policy.strict())
+        >>> guard.write("session.notes", "Safe memory content")
     """
 
     def __init__(
@@ -114,17 +129,54 @@ class MemoryGuard:
 
     @property
     def policy(self) -> Policy:
+        """Get the active security policy configuration.
+
+        Returns:
+            Policy: The policy engine instance currently enforced by this guard.
+
+        Example:
+            >>> guard = MemoryGuard(policy=Policy.strict())
+            >>> print(guard.policy.default_action)
+        """
         return self._policy
 
     @property
     def events(self) -> list[SecurityEvent]:
+        """Get the log of security events emitted during operations.
+
+        Returns:
+            list[SecurityEvent]: A copy of the list of recorded security events.
+
+        Example:
+            >>> guard = MemoryGuard()
+            >>> print(len(guard.events))
+        """
         return list(self._events)
 
     @property
     def quarantine(self) -> dict[str, Any]:
+        """Get the dictionary of quarantined memory writes.
+
+        Returns:
+            dict[str, Any]: A copy of the dictionary holding quarantined keys and their values.
+
+        Example:
+            >>> guard = MemoryGuard()
+            >>> print(guard.quarantine)
+        """
         return dict(self._quarantine)
 
     def add_event_handler(self, handler: EventHandler) -> None:
+        """Register a callback to handle emitted security events.
+
+        Args:
+            handler: A callable that accepts a single SecurityEvent object
+                and performs custom handling (e.g. logging, SIEM forwarding).
+
+        Example:
+            >>> guard = MemoryGuard()
+            >>> guard.add_event_handler(lambda ev: print(ev.message))
+        """
         self._handlers.append(handler)
 
     def baseline(self, key: str, value: Any | None = None) -> str:
@@ -152,6 +204,15 @@ class MemoryGuard:
 
     @property
     def current_task(self) -> str | None:
+        """Get the active task identifier context.
+
+        Returns:
+            str | None: The active task ID, or None if no task context is set.
+
+        Example:
+            >>> guard = MemoryGuard(current_task="task_123")
+            >>> print(guard.current_task)
+        """
         return self._current_task
 
     def set_current_task(self, task_id: str | None) -> None:
@@ -160,9 +221,37 @@ class MemoryGuard:
         self._cross_task_detector.set_current_task(task_id)
 
     def classify(self, key: str) -> MemoryClass | None:
+        """Get the classification class associated with a memory key.
+
+        Args:
+            key: The memory key to retrieve the classification for.
+
+        Returns:
+            MemoryClass | None: The memory class of the key, or None if the key
+                is not classified.
+
+        Example:
+            >>> guard = MemoryGuard()
+            >>> guard.write("session.notes", "Some text", cls="scratch")
+            >>> print(guard.classify("session.notes"))
+        """
         return self._classification.get(key)
 
     def origin_task(self, key: str) -> str | None:
+        """Get the ID of the task that originally wrote the specified memory key.
+
+        Args:
+            key: The memory key to check.
+
+        Returns:
+            str | None: The task ID that authored the key, or None if no task
+                is associated with it.
+
+        Example:
+            >>> guard = MemoryGuard(current_task="task_123")
+            >>> guard.write("session.notes", "Task data")
+            >>> print(guard.origin_task("session.notes"))
+        """
         return self._classification.task_of(key)
 
     def promote(
@@ -255,26 +344,29 @@ class MemoryGuard:
         cls: MemoryClass | str | None = None,
         task_id: str | None = None,
     ) -> Action:
-        """Inspect and (if policy allows) commit a write. Returns the action taken.
+        """Write a value to the guarded memory store.
 
-        Parameters
-        ----------
-        source_class
-            Provenance of this write — drives the self-reinforcement detector
-            and per-class telemetry. Use :class:`SourceClass.AGENT_AUTHORED`
-            for writes the agent generates from its own reasoning;
-            :class:`SourceClass.EXTERNAL_TOOL` for tool outputs;
-            :class:`SourceClass.USER_INPUT` for direct user content.
-        receipt_uri
-            Optional pointer into an external audit / receipt chain (e.g.
-            an Ed25519 co-signed receipt URI). Stored on the emitted
-            ``SecurityEvent`` so downstream SOC tooling can correlate
-            guard decisions with execution receipts.
-        cls
-            Provenance class for the entry (see :class:`MemoryClass`).
-        task_id
-            Override the task scope for this entry (defaults to the guard's
-            current task).
+        The value passes through the detector pipeline and policy engine
+        before being persisted. Depending on policy rules, the write may
+        be allowed, redacted, quarantined, or blocked.
+
+        Args:
+            key: The memory key to write to (e.g. 'session.notes').
+            value: The value to store.
+            source: The identifier of the writer (e.g. 'agent'). Defaults to 'agent'.
+            source_class: Provenance classification of this write. Use SourceClass.AGENT_AUTHORED
+                for agent reasoning, SourceClass.EXTERNAL_TOOL for tool outputs, or
+                SourceClass.USER_INPUT for user content. Defaults to None.
+            receipt_uri: Optional URI pointing to an external audit receipt. Defaults to None.
+            cls: Provenance classification class for the entry. Defaults to None.
+            task_id: Optional task identifier override for cross-task checks. Defaults to None.
+
+        Returns:
+            Action: The action taken by the policy engine (ALLOW, REDACT, QUARANTINE, or BLOCK).
+
+        Raises:
+            PolicyViolation: If the policy blocks the write.
+            ClassificationError: If the write would illegal reclassify an existing key.
         """
         normalised_source_class: SourceClass = _coerce_source_class(source_class)
 
@@ -397,7 +489,24 @@ class MemoryGuard:
         return decision
 
     def read(self, key: str, default: Any = None, *, sink: str = "agent") -> Any:
-        """Read with integrity verification and outbound leakage screening."""
+        """Read a value from the guarded memory store.
+
+        The read triggers integrity verification checks on baseline-monitored keys
+        and runs outbound leakage screening before returning the value.
+
+        Args:
+            key: The memory key to read from.
+            default: The default value to return if the key is not found. Defaults to None.
+            sink: The destination/consumer of the read data. Defaults to 'agent'.
+
+        Returns:
+            Any: The stored memory value, which may be redacted or modified by detectors,
+                or the default value if the key does not exist.
+
+        Raises:
+            PolicyViolation: If the policy blocks the read.
+            IntegrityError: If the key baseline check fails on read.
+        """
         if key not in self._store:
             return default
 
@@ -456,6 +565,23 @@ class MemoryGuard:
         return value
 
     def delete(self, key: str) -> None:
+        """Delete a key and its associated metadata from the memory store.
+
+        This clears the value from storage and resets any associated integrity baselines,
+        classification metadata, and detector historical states. Protected keys cannot
+        be deleted.
+
+        Args:
+            key: The memory key to delete.
+
+        Raises:
+            PolicyViolation: If the key matches protected key patterns, blocking deletion.
+
+        Example:
+            >>> guard = MemoryGuard()
+            >>> guard.write("session.scratch", "temporary data")
+            >>> guard.delete("session.scratch")
+        """
         if self._protected_detector.matches(key):
             self._emit(
                 detector="protected_key",
@@ -526,13 +652,59 @@ class MemoryGuard:
     # ---- snapshots ----------------------------------------------------
 
     def snapshot(self, label: str = "manual") -> Snapshot:
+        """Capture a point-in-time snapshot of the guarded memory store.
+
+        This creates a forensic snapshot of the current state of the memory store,
+        calculates an integrity digest, and stores it in the snapshot history
+        for audit or rollback capability.
+
+        Args:
+            label: A descriptive tag for the snapshot (e.g. 'manual', 'pre-block').
+                Defaults to 'manual'.
+
+        Returns:
+            Snapshot: The captured snapshot instance containing ID, timestamp,
+                label, copy of data, and SHA-256 digest.
+
+        Example:
+            >>> guard = MemoryGuard()
+            >>> guard.write("session.user", "Alice")
+            >>> snap = guard.snapshot(label="user_session_init")
+            >>> print(snap.snapshot_id)
+        """
         return self._snapshots.capture(self._dump_store(), label=label)
 
     def list_snapshots(self) -> list[Snapshot]:
+        """List all captured snapshots in the snapshot store.
+
+        Returns:
+            list[Snapshot]: A list of all historical snapshots, ordered from
+                oldest to newest.
+
+        Example:
+            >>> guard = MemoryGuard()
+            >>> guard.snapshot(label="backup_1")
+            >>> print(len(guard.list_snapshots()))
+        """
         return self._snapshots.list()
 
     def rollback(self, snapshot_id: str | None = None) -> Snapshot:
-        """Restore the store to a known-good snapshot (latest if id omitted)."""
+        """Restore the memory store to a known-good snapshot state.
+
+        This method clears current stored data and restores all keys and values
+        from the specified snapshot. If no snapshot ID is provided, the latest
+        captured snapshot is used.
+
+        Args:
+            snapshot_id: The unique identifier of the snapshot to restore.
+                If None, the latest snapshot is used. Defaults to None.
+
+        Returns:
+            Snapshot: The restored snapshot instance.
+
+        Raises:
+            LookupError: If no snapshot is found in the snapshot store.
+        """
         snap = (
             self._snapshots.get(snapshot_id)
             if snapshot_id

--- a/src/agent_memory_guard/policies/policy.py
+++ b/src/agent_memory_guard/policies/policy.py
@@ -56,6 +56,24 @@ class PolicyRule:
 
 @dataclass
 class Policy:
+    """Security policy configuration for MemoryGuard operations.
+
+    A policy dictates the action to take (ALLOW, REDACT, QUARANTINE, or BLOCK)
+    when detectors match security anomalies or prompt injections. It defines key rules,
+    protected keys, and immutable baselines.
+
+    Attributes:
+        default_action: The fallback action when no rules match. Defaults to Action.ALLOW.
+        protected_keys: Glob patterns for keys protected against deletion or modification.
+        immutable_keys: Glob patterns for keys monitored with cryptographic integrity checks.
+        rules: Ordered list of rules to evaluate when scanning keys.
+        version: Policy syntax version. Defaults to 1.
+
+    Example:
+        >>> policy = Policy.strict()
+        >>> policy.decide("prompt_injection", Severity.HIGH, "session.notes")
+        <Action.BLOCK: 'block'>
+    """
     default_action: Action = Action.ALLOW
     protected_keys: tuple[str, ...] = ()
     immutable_keys: tuple[str, ...] = ()
@@ -261,7 +279,23 @@ def _severity_rank(s: Severity) -> int:
 
 
 def load_policy(source: str | Path | dict[str, Any]) -> Policy:
-    """Load a policy from a YAML string, file path, or already-parsed dict."""
+    """Load a security policy from a YAML string, a file path, or a dictionary.
+
+    This function parses declarative policies that dictate the behavior of
+    MemoryGuard when checking memory operations.
+
+    Args:
+        source: The YAML policy configuration. This can be a file path (Path object),
+            a raw YAML string, or an already-parsed dictionary representation of the policy.
+
+    Returns:
+        Policy: The loaded Policy configuration instance.
+
+    Example:
+        >>> from pathlib import Path
+        >>> policy = load_policy("version: 1\\ndefault_action: allow")
+        >>> print(policy.default_action)
+    """
     if isinstance(source, dict):
         return Policy.from_dict(source)
     if isinstance(source, Path):

--- a/src/agent_memory_guard/storage/memory_store.py
+++ b/src/agent_memory_guard/storage/memory_store.py
@@ -16,7 +16,19 @@ class MemoryStore(Protocol):
 
 
 class InMemoryStore:
-    """Reference dict-backed implementation used by tests and examples."""
+    """In-memory dictionary-backed implementation of MemoryStore.
+
+    This reference implementation is used for testing, examples, and simple
+    ephemeral key-value storage.
+
+    Args:
+        initial: Optional dictionary with initial key-value mappings to load.
+            Defaults to None.
+
+    Example:
+        >>> store = InMemoryStore({"session.user": "Alice"})
+        >>> print(store.get("session.user"))
+    """
 
     def __init__(self, initial: dict[str, Any] | None = None) -> None:
         self._data: dict[str, Any] = dict(initial or {})

--- a/src/agent_memory_guard/storage/snapshots.py
+++ b/src/agent_memory_guard/storage/snapshots.py
@@ -23,7 +23,21 @@ class Snapshot:
 
 
 class SnapshotStore:
-    """Bounded ring buffer of memory snapshots for forensics and rollback."""
+    """Bounded ring buffer of memory snapshots for forensics and rollback.
+
+    This class maintains a historical queue of memory snapshots. It will discard
+    oldest snapshots once the configured capacity threshold is exceeded.
+
+    Args:
+        max_snapshots: The maximum number of snapshots to retain. Defaults to 50.
+
+    Raises:
+        ValueError: If max_snapshots is less than 1.
+
+    Example:
+        >>> store = SnapshotStore(max_snapshots=10)
+        >>> snap = store.capture({"key": "value"}, label="test")
+    """
 
     def __init__(self, max_snapshots: int = 50) -> None:
         if max_snapshots < 1:


### PR DESCRIPTION
<!-- Thanks for contributing to OWASP Agent Memory Guard. -->

## Summary

Adds Google-style docstrings to all public classes, methods, and functions across the codebase, covering `MemoryGuard`, all `detectors`, `Policy`, `storage` classes, and `SecurityEvent` dataclass fields. 

Closes #2 

## Type of change

- [ ] Bug fix
- [ ] New feature / detector / policy primitive
- [ ] Framework or backend adapter
- [x] Docs / examples
- [ ] Refactor / internal

## Testing

pytest → 67 passed

- [x] `pytest` passes locally
- [ ] Added or updated tests for the change
- [x] If docs changed, links and code samples render correctly

## Checklist

- [x] Follows the conventions in [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] No secrets, credentials, or PII committed
- [x] No unverifiable claims added to README or docs
